### PR TITLE
[+] added support monolog/monolog:^2.7 #WTT-13113

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "squizlabs/php_codesniffer": "3.*",
         "guzzlehttp/guzzle": "~6.3",
-        "monolog/monolog": "~1.23",
+        "monolog/monolog": "~1.23|^2.7",
         "php": ">=7.0"
     }
 }


### PR DESCRIPTION
Добавлена поддержка логера `"monolog/monolog":"^2.7"`. Это необходимо, чтобы пакет поддерживался PHP8 в случае, если ставится пакет "whotrades/monolog-extensions" с поддержкой PHP8